### PR TITLE
basic error events send back to both players

### DIFF
--- a/src/game_logic/mod.rs
+++ b/src/game_logic/mod.rs
@@ -10,6 +10,7 @@ mod side;
 pub use side::Side;
 
 mod speedtable;
+pub use speedtable::SpeedError;
 pub use speedtable::SpeedTable;
 
 mod playerview;

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,17 +39,11 @@ async fn start_game(mut p1: (Sender, Reciever), mut p2: (Sender, Reciever)) -> R
     loop {
         let (player_move, player) = wait_for_player_move(&mut p1.1, &mut p2.1).await?;
 
-        match player_move {
-            PlayerAction::DrawCard => {
-                table.player_draw_card(player);
-            }
-            PlayerAction::Flip => {
-                table.flip_middle_cards();
-            }
-            PlayerAction::PlaceCard(hand_index, side) => {
-                table.place_card(player, side, hand_index);
-            }
-        }
+        let move_result = match player_move {
+            PlayerAction::DrawCard => table.player_draw_card(player),
+            PlayerAction::Flip => table.flip_middle_cards(),
+            PlayerAction::PlaceCard(hand_index, side) => table.place_card(player, side, hand_index),
+        };
         send_player_message(&mut p1.0, &mut p2.0, &table, ServerAction::SetBoard).await;
     }
 }

--- a/src/server_message.rs
+++ b/src/server_message.rs
@@ -5,10 +5,8 @@ use crate::game_logic::{Player, PlayerView};
 #[derive(Clone, Copy, Serialize)]
 pub enum ServerAction {
     SetBoard,
-    PlayerMove,
-    OpponentMove,
-    IllegalMove,
     GameWon,
+    GameLost,
 }
 
 #[derive(Serialize)]

--- a/src/server_message.rs
+++ b/src/server_message.rs
@@ -5,6 +5,7 @@ use crate::game_logic::{Player, PlayerView};
 #[derive(Clone, Copy, Serialize)]
 pub enum ServerAction {
     SetBoard,
+    NormalMove,
     GameWon,
     GameLost,
 }


### PR DESCRIPTION
The framework to send basic error messages to players has been added. Now when one player wins the game, the message is sent to the client and the opponent client gets the game lost message.